### PR TITLE
Turn on "folders"

### DIFF
--- a/pythia.yml
+++ b/pythia.yml
@@ -15,6 +15,7 @@ project:
 site:
   template: book-theme
   options:
+    folders: true
     favicon: https://raw.githubusercontent.com/ProjectPythia/pythia-config/main/favicon.ico
     logo: https://raw.githubusercontent.com/ProjectPythia/pythia-config/main/logos/pythia_logo-white-rtext-blue.svg
     logo_dark: https://raw.githubusercontent.com/ProjectPythia/pythia-config/main/logos/pythia_logo-white-rtext.svg


### PR DESCRIPTION
This should add the section names back to the URL paths.

Docs: https://mystmd.org/guide/table-of-contents#make-your-url-match-your-folder-structure

Relates to: ProjectPythia/pythia-foundations#523