### PR TITLE
feat: add contributors to upstream

### DIFF
--- a/pythia.yml
+++ b/pythia.yml
@@ -27,6 +27,7 @@ project:
     - name: Kevin Tyle
       id: ktyle
       orcid: 0000-0001-5249-9665
+      affiliation: University at Albany (State University of New York)
     
 site:
   template: book-theme


### PR DESCRIPTION
Use the `contributors` field so that downstream we can refer to authors by their GitHub IDs.

These were taken from blogs, and should be extended as needed with new authors and metadata.

@jukent @ktyle @clyne @brian-rose would you mind confirming that your ORCIDs are correct, and add any other metadata you're comfortable aggregating here. It will show up e.g. on blog posts that you're added to as an author or contributor.