### PR TITLE
Set logo_url to always point to the pythia home page

### DIFF
--- a/pythia.yml
+++ b/pythia.yml
@@ -36,6 +36,7 @@ site:
     favicon: https://raw.githubusercontent.com/ProjectPythia/pythia-config/main/favicon.ico
     logo: https://raw.githubusercontent.com/ProjectPythia/pythia-config/main/logos/pythia_logo-white-rtext-blue.svg
     logo_dark: https://raw.githubusercontent.com/ProjectPythia/pythia-config/main/logos/pythia_logo-white-rtext.svg
+    logo_url: https://projectpythia.org
   nav:
     - title: Home
       url: https://projectpythia.org


### PR DESCRIPTION
<!--
Project Pythia has automated review requests. If you are not ready for reviews on this contribution, please
open this Pull Request as a "Draft" by clicking the dropdown on the green "Create Pull Request" button in the
lower right corner here.
-->
Closes #11 

Unfortunately we can't really see if this works until it gets merged (#9)